### PR TITLE
Add documentation for macOS and Make the token extraction more robust

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ python3 slack_export.py all
 ```
 
 You can also export
-- only direct messages by running ``` python slack_export.py im ```
-- only group direct messages by running ``` python slack_export.py mpim ```
-- only private channels by running ``` python slack_export.py private_channel ```
-- only public channels by running ``` python slack_export.py public_channel ```
+- only direct messages by running ``` python3 slack_export.py im ```
+- only group direct messages by running ``` python3 slack_export.py mpim ```
+- only private channels by running ``` python3 slack_export.py private_channel ```
+- only public channels by running ``` python3 slack_export.py public_channel ```

--- a/README.md
+++ b/README.md
@@ -8,16 +8,26 @@ If your workspace is on Slack’s Standard plan, you can use Slack API to export
 
 ## Dependencies
 
-1. Script runs on python(specifically python 3).
+1. Script runs on python (specifically python 3).
+3. You must have the `requests` package installed with `pip3 install requests`
 2. You need to get your user token with below scope and update token.txt with your token.
 
 ![Alt text](https://github.com/aaskan/Slack-Export/blob/master/ReadMeAsset/userscope.png)
 
+### macOS Mojave
+
+macOS 10.14 doesn't come with python 3 out of the box, you must install it first and the easiest way is using homebrew
+
+1. Install Homebrew (See https://brew.sh/)
+2. Run `brew install python`
+3. Install/Fulfill the dependencies outlined above
+
 ## Usage
 
 Exporting all direct messages, group direct messages, private and public channels that the user participates in: 
+
 ``` 
-python slack_export.py all 
+python3 slack_export.py all 
 ```
 
 You can also export
@@ -25,4 +35,3 @@ You can also export
 - only group direct messages by running ``` python slack_export.py mpim ```
 - only private channels by running ``` python slack_export.py private_channel ```
 - only public channels by running ``` python slack_export.py public_channel ```
-

--- a/slack_export.py
+++ b/slack_export.py
@@ -9,7 +9,8 @@ if not os.path.exists(OUTPUT):
     os.makedirs(OUTPUT)
 
 f = open("token.txt", "r")
-token = f.read()
+# Remove any leading or trailing space characters (Including new lines) from the token
+token = f.read().strip()
 available_types = ['im', 'mpim', 'private_channel', 'public_channel', 'all']
 requested_type = sys.argv[1]
 assert requested_type in available_types, 'Type is not right. Please choose one of the {}'.format(available_types)


### PR DESCRIPTION
I tested this tool on my own workspace and it worked with a few modifications I'm requesting to merge:

- Improved README with instructions for macOS Mojave (The version I'm currently using, although it may work with other versions)
- Improved token reading by removing any leading or trailing spaces. Turns out my machine for some reason added a new line at the end of the tocken when the file was read and that was causing authentication issues. It works for mw now